### PR TITLE
Subscriptions and balances; Addresses as link to non-segregated taproot asset balances

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -181,13 +181,15 @@ func main() {
 	// Subscribe to LND invoice updates in the background
 	backgroundWg.Add(1)
 	go func() {
-		err = svc.StartInvoiceRoutine(backGroundCtx)
+		//err = svc.StartInvoiceRoutine(backGroundCtx)
+		err = svc.StartReceiveSubscription(backGroundCtx)
 		if err != nil {
 			sentry.CaptureException(err)
 			//we want to restart in case of an error here
 			svc.Logger.Fatal(err)
 		}
-		svc.Logger.Info("Invoice routine done")
+		//svc.Logger.Info("Invoice routine done")
+		svc.Logger.Info("Tapd Receive routine done")
 		backgroundWg.Done()
 	}()
 	// get relays from DB

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -148,6 +148,7 @@ func main() {
 		TapdClient:     tapdClient,
 		Logger:         logger,
 		InvoicePubSub:  service.NewPubsub(),
+		TaprootAssetPubSub: service.NewTapdPubsub(),
 		RabbitMQClient: rabbitmqClient,
 	}
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -190,7 +190,7 @@ func main() {
 		svc.Logger.Info("Invoice routine done")
 		backgroundWg.Done()
 	}()
-	// TODO get relays from DB
+	// get relays from DB
 	relays, err := svc.GetRelays(backGroundCtx)
 	if err != nil && len(relays) > 0 {
 		sentry.CaptureException(err)

--- a/common/globals.go
+++ b/common/globals.go
@@ -1,7 +1,7 @@
 package common
 // bitcoin - init assets table row
 const BTC_INTERNAL_ASSET_ID = 1
-const BTC_TA_ASSET_ID       = "native-asset-bitcoin"
+const BTC_TA_ASSET_ID       = "btc"
 const BTC_ASSET_NAME        = "bitcoin"
 
 // https://lightning.engineering/api-docs/api/taproot-assets/universe/query-asset-stats#taprpcassettype

--- a/common/globals.go
+++ b/common/globals.go
@@ -12,6 +12,9 @@ const (
 )
 
 const (
+	TapdReceiveEvent = "tapd_receive_event"
+	TapdSendEvent    = "tapd_send_event"
+	
 	InvoiceTypeOutgoing = "outgoing"
 	InvoiceTypePaid     = "paid_invoice"
 	InvoiceTypeIncoming = "incoming"

--- a/controllers/addinvoice.ctrl.go
+++ b/controllers/addinvoice.ctrl.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"net/http"
 
+	"github.com/getAlby/lndhub.go/common"
 	"github.com/getAlby/lndhub.go/lib/responses"
 	"github.com/getAlby/lndhub.go/lib/service"
 	"github.com/labstack/echo/v4"
@@ -61,7 +62,7 @@ func AddInvoice(c echo.Context, svc *service.LndhubService, userID int64) error 
 		return c.JSON(http.StatusBadRequest, responses.BadArgumentsError)
 	}
 	// TODO hard-coding value as code is likely to be discarded for us
-	resp, err := svc.CheckIncomingPaymentAllowed(c, amount, 1, userID)
+	resp, err := svc.CheckIncomingPaymentAllowed(c, amount, common.BTC_TA_ASSET_ID, userID)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, responses.GeneralServerError)
 	}

--- a/controllers/balance.ctrl.go
+++ b/controllers/balance.ctrl.go
@@ -2,8 +2,7 @@ package controllers
 
 import (
 	"net/http"
-	"strconv"
-
+	"github.com/getAlby/lndhub.go/common"
 	"github.com/getAlby/lndhub.go/lib/responses"
 	"github.com/getAlby/lndhub.go/lib/service"
 	"github.com/labstack/echo/v4"
@@ -28,12 +27,12 @@ type BalanceResponse struct {
 func (controller *BalanceController) Balance(c echo.Context) error {
 	userId := c.Get("UserID").(int64)
 	assetParam := c.Param("asset_id")
-	assetId, err := strconv.ParseInt(assetParam, 10, 64)
 	// default to bitcoin if error parsing the param
-	if  err != nil {
-		assetId = 1
+	if  assetParam == "" {
+		assetParam = common.BTC_TA_ASSET_ID
 	}
-	balance, err := controller.svc.CurrentUserBalance(c.Request().Context(), assetId, userId)
+
+	balance, err := controller.svc.CurrentUserBalance(c.Request().Context(), assetParam, userId)
 	if err != nil {
 		c.Logger().Errorj(
 			log.JSON{

--- a/controllers/keysend.ctrl.go
+++ b/controllers/keysend.ctrl.go
@@ -75,7 +75,7 @@ func (controller *KeySendController) KeySend(c echo.Context) error {
 		})
 	}
 	// TODO hard-coding value as code is likely to be discarded for us
-	resp, err := controller.svc.CheckOutgoingPaymentAllowed(c, lnPayReq, 1, userID)
+	resp, err := controller.svc.CheckOutgoingPaymentAllowed(c, lnPayReq, common.BTC_TA_ASSET_ID, userID)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, responses.GeneralServerError)
 	}

--- a/controllers/payinvoice.ctrl.go
+++ b/controllers/payinvoice.ctrl.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/getAlby/lndhub.go/common"
 	"github.com/getAlby/lndhub.go/lib"
 	"github.com/getAlby/lndhub.go/lib/responses"
 	"github.com/getAlby/lndhub.go/lib/service"
@@ -90,7 +91,7 @@ func (controller *PayInvoiceController) PayInvoice(c echo.Context) error {
 		lnPayReq.PayReq.NumSatoshis = amt
 	}
 	// TODO hard-coding this error as code is likely to be discarded for our purposes
-	resp, err := controller.svc.CheckOutgoingPaymentAllowed(c, lnPayReq, 1, userID)
+	resp, err := controller.svc.CheckOutgoingPaymentAllowed(c, lnPayReq, common.BTC_TA_ASSET_ID, userID)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, responses.GeneralServerError)
 	}

--- a/controllers_v2/balance.ctrl.go
+++ b/controllers_v2/balance.ctrl.go
@@ -2,8 +2,7 @@ package v2controllers
 
 import (
 	"net/http"
-	"strconv"
-
+	"github.com/getAlby/lndhub.go/common"
 	"github.com/getAlby/lndhub.go/lib/responses"
 	"github.com/getAlby/lndhub.go/lib/service"
 	"github.com/labstack/echo/v4"
@@ -39,12 +38,11 @@ type BalanceResponse struct {
 func (controller *BalanceController) Balance(c echo.Context) error {
 	userId := c.Get("UserID").(int64)
 	assetParam := c.Param("asset_id")
-	assetId, err := strconv.ParseInt(assetParam, 10, 64)
 	// default to bitcoin if error parsing the param
-	if  err != nil {
-		assetId = 1
+	if  assetParam == "" {
+		assetParam = common.BTC_TA_ASSET_ID
 	}
-	balance, err := controller.svc.CurrentUserBalance(c.Request().Context(), assetId, userId)
+	balance, err := controller.svc.CurrentUserBalance(c.Request().Context(), assetParam, userId)
 	if err != nil {
 		c.Logger().Errorj(
 			log.JSON{

--- a/controllers_v2/invoice.ctrl.go
+++ b/controllers_v2/invoice.ctrl.go
@@ -140,14 +140,14 @@ func (controller *InvoiceController) GetIncomingInvoices(c echo.Context) error {
 
 type AddInvoiceRequestBody struct {
 	Amount          int64  `json:"amount" validate:"gte=0"`
-	AssetId        int64     `json:"asset_id"`
+	TaAssetId       string `json:"ta_asset_id"`
 	Description     string `json:"description"`
 	DescriptionHash string `json:"description_hash" validate:"omitempty,hexadecimal,len=64"`
 }
 // TODO confirm that no other info is needed ehre
 type AddInvoiceResponseBody struct {
 	PaymentHash    string    `json:"payment_hash"`
-	AssetId        int64     `json:"asset_id"`
+	TaAssetId      string    `json:"ta_asset_id"`
 	PaymentRequest string    `json:"payment_request"`
 	ExpiresAt      time.Time `json:"expires_at"`
 	CreatedAt      time.Time `json:"created_at"`
@@ -180,7 +180,7 @@ func (controller *InvoiceController) AddInvoice(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, responses.BadArgumentsError)
 	}
 
-	resp, err := controller.svc.CheckIncomingPaymentAllowed(c, body.Amount, body.AssetId, userID)
+	resp, err := controller.svc.CheckIncomingPaymentAllowed(c, body.Amount, body.TaAssetId, userID)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, responses.GeneralServerError)
 	}
@@ -197,7 +197,7 @@ func (controller *InvoiceController) AddInvoice(c echo.Context) error {
 	}
 	responseBody := AddInvoiceResponseBody{
 		PaymentHash:    invoice.RHash,
-		AssetId: 		invoice.AssetID,
+		TaAssetId: 	    invoice.TaAssetID,
 		PaymentRequest: invoice.PaymentRequest,
 		ExpiresAt:      invoice.ExpiresAt.Time,
 		CreatedAt:      invoice.CreatedAt,

--- a/controllers_v2/payinvoice.ctrl.go
+++ b/controllers_v2/payinvoice.ctrl.go
@@ -24,13 +24,13 @@ func NewPayInvoiceController(svc *service.LndhubService) *PayInvoiceController {
 }
 
 type PayInvoiceRequestBody struct {
-	Invoice string `json:"invoice" validate:"required"`
-	AssetID int64   `json:"asset_id" validate:"omitempty,gte=1"` // NOTE: this is defaulting to bitcoin balance
-	Amount  int64  `json:"amount" validate:"omitempty,gte=0"`
+	Invoice   string `json:"invoice" validate:"required"`
+	TaAssetID string   `json:"ta_asset_id" validate:"omitempty,gte=1"` // NOTE: this is defaulting to bitcoin balance
+	Amount    int64  `json:"amount" validate:"omitempty,gte=0"`
 }
 type PayInvoiceResponseBody struct {
 	PaymentRequest  string `json:"payment_request,omitempty"`
-	AssetID         int64  `json:"asset_id,omitempty"`
+	TaAssetID       string  `json:"ta_asset_id,omitempty"`
 	Amount          int64  `json:"amount,omitempty"`
 	Fee             int64  `json:"fee"`
 	Description     string `json:"description,omitempty"`
@@ -100,7 +100,7 @@ func (controller *PayInvoiceController) PayInvoice(c echo.Context) error {
 		}
 		lnPayReq.PayReq.NumSatoshis = amt
 	}
-	resp, err := controller.svc.CheckOutgoingPaymentAllowed(c, lnPayReq, reqBody.AssetID, userID)
+	resp, err := controller.svc.CheckOutgoingPaymentAllowed(c, lnPayReq, reqBody.TaAssetID, userID)
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, responses.GeneralServerError)
 	}

--- a/db/migrations/20220115171101_init.up.sql
+++ b/db/migrations/20220115171101_init.up.sql
@@ -92,29 +92,6 @@ CREATE TABLE invoices (
         ON DELETE NO ACTION
 );
 --bun:split
-CREATE TABLE transaction_entries (
-    id SERIAL PRIMARY KEY,
-    user_id bigint NOT NULL,
-    invoice_id bigint NOT NULL,
-    parent_id bigint,
-    credit_account_id bigint NOT NULL,
-    debit_account_id bigint NOT NULL,
-    amount bigint NOT NULL,
-    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    CONSTRAINT fk_user
-        FOREIGN KEY(user_id)
-        REFERENCES users(id)
-        ON DELETE CASCADE,
-    CONSTRAINT fk_credit_account
-        FOREIGN KEY(credit_account_id)
-        REFERENCES accounts(id)
-        ON DELETE CASCADE,
-    CONSTRAINT fk_debit_account
-        FOREIGN KEY(debit_account_id)
-        REFERENCES accounts(id)
-        ON DELETE CASCADE
-);
---bun:split
 CREATE TABLE addresses (
     id SERIAL PRIMARY KEY,
     user_id bigint NOT NULL,
@@ -130,6 +107,35 @@ CREATE TABLE addresses (
     CONSTRAINT fk_asset
         FOREIGN KEY(ta_asset_id)
         REFERENCES assets(ta_asset_id)
+        ON DELETE NO ACTION
+);
+--bun:split
+CREATE TABLE transaction_entries (
+    id SERIAL PRIMARY KEY,
+    user_id bigint NOT NULL,
+    invoice_id bigint,
+    parent_id bigint,
+    addr character varying,
+    credit_account_id bigint NOT NULL,
+    debit_account_id bigint NOT NULL,
+    amount bigint NOT NULL,
+    outpoint character varying,
+    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    CONSTRAINT fk_user
+        FOREIGN KEY(user_id)
+        REFERENCES users(id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_credit_account
+        FOREIGN KEY(credit_account_id)
+        REFERENCES accounts(id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_debit_account
+        FOREIGN KEY(debit_account_id)
+        REFERENCES accounts(id)
+        ON DELETE CASCADE
+    CONSTRAINT fk_addr
+        FOREIGN KEY(addr)
+        REFERENCES addresses(addr)
         ON DELETE NO ACTION
 );
 --bun:split

--- a/db/migrations/20220115171101_init.up.sql
+++ b/db/migrations/20220115171101_init.up.sql
@@ -50,15 +50,15 @@ CREATE TABLE assets (
 CREATE TABLE accounts (
     id SERIAL PRIMARY KEY,
     user_id bigint NOT NULL,
-    asset_id bigint NOT NULL,
+    ta_asset_id character varying NOT NULL,
     type character varying NOT NULL,
     CONSTRAINT fk_user
         FOREIGN KEY(user_id)
         REFERENCES users(id)
         ON DELETE CASCADE,
     CONSTRAINT fk_asset
-        FOREIGN KEY(asset_id)
-        REFERENCES assets(id)
+        FOREIGN KEY(ta_asset_id)
+        REFERENCES assets(ta_asset_id)
         ON DELETE NO ACTION
 );
 --bun:split
@@ -66,7 +66,7 @@ CREATE TABLE invoices (
     id SERIAL PRIMARY KEY,
     type character varying,
     user_id bigint,
-    asset_id bigint,
+    ta_asset_id character varying NOT NULL,
     amount bigint,
     memo character varying,
     description_hash character varying,
@@ -87,8 +87,8 @@ CREATE TABLE invoices (
         REFERENCES users(id)
         ON DELETE CASCADE,
     CONSTRAINT fk_asset
-        FOREIGN KEY(asset_id)
-        REFERENCES assets(id)
+        FOREIGN KEY(ta_asset_id)
+        REFERENCES assets(ta_asset_id)
         ON DELETE NO ACTION
 );
 --bun:split
@@ -132,7 +132,7 @@ CREATE TABLE transaction_entries (
     CONSTRAINT fk_debit_account
         FOREIGN KEY(debit_account_id)
         REFERENCES accounts(id)
-        ON DELETE CASCADE
+        ON DELETE CASCADE,
     CONSTRAINT fk_addr
         FOREIGN KEY(addr)
         REFERENCES addresses(addr)

--- a/db/migrations/20220115171101_init.up.sql
+++ b/db/migrations/20220115171101_init.up.sql
@@ -8,8 +8,7 @@ CREATE TABLE relays (
 --bun:split
 INSERT INTO relays(id, uri, relay_name) SELECT 1, 'wss://dev-relay.nostrassets.com', 'internal-dev' WHERE NOT EXISTS (SELECT id FROM relays WHERE id = 1);
 --bun:split
-INSERT INTO relays(id, uri, relay_name) SELECT 2, 'wss://relay.damus.io', 'damus' WHERE NOT EXISTS (SELECT id FROM relays WHERE id = 2);
---bun:split
+
 CREATE TABLE filters (
     relay_id bigint PRIMARY KEY,
     last_event_seen bigint,
@@ -22,8 +21,6 @@ CREATE TABLE filters (
 );
 --bun:split
 INSERT INTO filters(relay_id, last_event_seen) SELECT 1, 1708201481 WHERE NOT EXISTS (SELECT relay_id FROM filters WHERE relay_id = 1);
---bun:split
-INSERT INTO filters(relay_id, last_event_seen) SELECT 2, 1708201481 WHERE NOT EXISTS (SELECT relay_id FROM filters WHERE relay_id = 2);
 --bun:split
 CREATE TABLE users (
     id SERIAL PRIMARY KEY,
@@ -43,7 +40,7 @@ CREATE TABLE events (
 --bun:split
 CREATE TABLE assets (
     id SERIAL PRIMARY KEY,
-    ta_asset_id character varying NOT NULL,
+    ta_asset_id character varying NOT NULL UNIQUE,
     asset_name character varying NOT NULL UNIQUE,
     asset_type int DEFAULT 0 NOT NULL,
     created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
@@ -121,7 +118,8 @@ CREATE TABLE transaction_entries (
 CREATE TABLE address (
     id SERIAL PRIMARY KEY,
     user_id bigint NOT NULL,
-    asset_id bigint NOT NULL,
+    ta_asset_id character NOT NULL,
+    amount bigint,
     addr character varying NOT NULL UNIQUE,
     created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
     updated_at timestamp with time zone,
@@ -130,8 +128,8 @@ CREATE TABLE address (
         REFERENCES users(id)
         ON DELETE CASCADE,
     CONSTRAINT fk_asset
-        FOREIGN KEY(asset_id)
-        REFERENCES assets(id)
+        FOREIGN KEY(ta_asset_id)
+        REFERENCES assets(ta_asset_id)
         ON DELETE NO ACTION
 );
 --bun:split

--- a/db/migrations/20220115171101_init.up.sql
+++ b/db/migrations/20220115171101_init.up.sql
@@ -115,10 +115,10 @@ CREATE TABLE transaction_entries (
         ON DELETE CASCADE
 );
 --bun:split
-CREATE TABLE address (
+CREATE TABLE addresses (
     id SERIAL PRIMARY KEY,
     user_id bigint NOT NULL,
-    ta_asset_id character NOT NULL,
+    ta_asset_id character varying NOT NULL,
     amount bigint,
     addr character varying NOT NULL UNIQUE,
     created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,

--- a/db/migrations/20220115171101_init.up.sql
+++ b/db/migrations/20220115171101_init.up.sql
@@ -44,15 +44,12 @@ CREATE TABLE events (
 CREATE TABLE assets (
     id SERIAL PRIMARY KEY,
     ta_asset_id character varying NOT NULL,
-    asset_name character varying NOT NULL,
+    asset_name character varying NOT NULL UNIQUE,
     asset_type int DEFAULT 0 NOT NULL,
     created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
     updated_at timestamp with time zone
 );
 --bun:split
-INSERT INTO assets(id, ta_asset_id, asset_name) SELECT 1, 'BTC', 'bitcoin' WHERE NOT EXISTS (SELECT id FROM assets WHERE id = 1);
---bun:split
-
 CREATE TABLE accounts (
     id SERIAL PRIMARY KEY,
     user_id bigint NOT NULL,
@@ -120,3 +117,21 @@ CREATE TABLE transaction_entries (
         REFERENCES accounts(id)
         ON DELETE CASCADE
 );
+--bun:split
+CREATE TABLE address (
+    id SERIAL PRIMARY KEY,
+    user_id bigint NOT NULL,
+    asset_id bigint NOT NULL,
+    addr character varying NOT NULL UNIQUE,
+    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp with time zone,
+    CONSTRAINT fk_user
+        FOREIGN KEY(user_id)
+        REFERENCES users(id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_asset
+        FOREIGN KEY(asset_id)
+        REFERENCES assets(id)
+        ON DELETE NO ACTION
+);
+--bun:split

--- a/db/migrations/2024022503000_universe_to_assets.go
+++ b/db/migrations/2024022503000_universe_to_assets.go
@@ -57,7 +57,7 @@ func init() {
 		// hardcode bitcoin row
 		bitcoin := models.Asset{
 			AssetName: "bitcoin",
-			TaAssetID: "BTC",
+			TaAssetID: "btc",
 			AssetType: 0,
 		}
 		assets = append(assets, bitcoin)

--- a/db/migrations/2024022503000_universe_to_assets.go
+++ b/db/migrations/2024022503000_universe_to_assets.go
@@ -1,0 +1,93 @@
+package migrations
+
+import (
+	"context"
+	"encoding/hex"
+	b64 "encoding/base64"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/getAlby/lndhub.go/db/models"
+	"github.com/getAlby/lndhub.go/lib"
+	"github.com/getAlby/lndhub.go/lib/service"
+	"github.com/getAlby/lndhub.go/tapd"
+	"github.com/joho/godotenv"
+	"github.com/kelseyhightower/envconfig"
+	"github.com/lightninglabs/taproot-assets/taprpc/universerpc"
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	Migrations.MustRegister(func(ctx context.Context, db *bun.DB) error {
+		// setup
+		c := &service.Config{}
+		// Load configruation from environment variables
+		err := godotenv.Load(".env")
+		if err != nil {
+			fmt.Println("Failed to load .env file")
+		}
+		err = envconfig.Process("", c)
+		if err != nil {
+			log.Fatalf("Error loading environment variables: %v", err)
+		}
+		// setup logger - although not used in other go migrations
+		logger := lib.Logger(c.LogFilePath)
+		// initialize tapd config
+		tapdConfig, err := tapd.LoadConfig()
+		// check for error
+		if err != nil {
+			return err
+		}
+		// initialize tapd client
+		tapdClient, err := tapd.InitTAPDClient(tapdConfig, logger, ctx)
+		// check for error
+		if err != nil {
+			return err
+		}
+		// get universe assets
+		req := universerpc.AssetRootRequest{}
+		res, err := tapdClient.GetUniverseAssets(ctx, &req)
+		// check for error
+		if err != nil {
+			return err
+		}
+		// for asset in universe, insert row to database if non exists
+		assets := []models.Asset{}
+		// hardcode bitcoin row
+		bitcoin := models.Asset{
+			AssetName: "bitcoin",
+			TaAssetID: "BTC",
+			AssetType: 0,
+		}
+		assets = append(assets, bitcoin)
+		// iterate over universe assets
+		for assetId, root := range res.UniverseRoots {
+			// get human-readable asset ID
+			rawAssetId := strings.Split(assetId, "-")[1]
+			decodedAssetId, err := hex.DecodeString(rawAssetId)
+			// check error
+			if err != nil {
+				return err
+			}
+			// final form
+			base64AssetId := b64.StdEncoding.EncodeToString(decodedAssetId)
+			// populate asset model
+			asset := models.Asset{
+				AssetName: root.AssetName,
+				TaAssetID: base64AssetId,
+				// TODO this is not on the universe rpc. hard-code for now
+				AssetType: 0,
+			}
+			// append for bulk upsert
+			assets = append(assets, asset)
+		}
+		// bulk upsert of assets
+		_, err = db.NewInsert().Model(&assets).On("conflict (asset_name) do nothing").Exec(ctx)
+		if err != nil {
+			return err
+		}
+		// success reached
+		return nil
+	}, nil)
+}

--- a/db/models/account.go
+++ b/db/models/account.go
@@ -5,7 +5,7 @@ type Account struct {
 	ID      int64  `bun:",pk,autoincrement"`
 	UserID  int64  `bun:",notnull"`
 	User    *User  `bun:"rel:belongs-to,join:user_id=id"`
-	AssetID int64  `bun:",notnull"`
-	Asset   *Asset `bun:"rel:has-one,join:asset_id=id"`
+	TaAssetID string  `bun:",notnull"`
+	Asset   *Asset `bun:"rel:has-one,join:ta_asset_id=ta_asset_id"`
 	Type    string `bun:",notnull"`
 }

--- a/db/models/address.go
+++ b/db/models/address.go
@@ -9,14 +9,14 @@ import (
 // Address : Address Model
 type Address struct {
 	ID         uint64 `bun:",pk,autoincrement"`
-	Address    string `bun:",notnull,unique"`
+	Addr       string `bun:",notnull,unique"`
 	UserId     uint64 `bun:",notnull"`
 	TaAssetID  string `bun:",notnull"`
 	Amount     uint64 
 	CreatedAt  time.Time `bun:",notnull,default:current_timestamp"`
 	UpdatedAt  bun.NullTime `bun:",nullzero"`
 	// relationship
-	Asset 	*Asset `bun:"rel:has-one,join:asset_id=ta_asset_id"`
+	Asset 	*Asset `bun:"rel:has-one,join:ta_asset_id=ta_asset_id"`
 }
 
 func (a *Address) BeforeAppendModel(ctx context.Context, query bun.Query) error {

--- a/db/models/address.go
+++ b/db/models/address.go
@@ -8,12 +8,15 @@ import (
 
 // Address : Address Model
 type Address struct {
-	ID         int64 `bun:",pk,autoincrement"`
+	ID         uint64 `bun:",pk,autoincrement"`
 	Address    string `bun:",notnull,unique"`
-	UserId     int64 `bun:",notnull"`
-	AssetId	   int64 `bun:",notnull"`
+	UserId     uint64 `bun:",notnull"`
+	TaAssetID  string `bun:",notnull"`
+	Amount     uint64 
 	CreatedAt  time.Time `bun:",notnull,default:current_timestamp"`
 	UpdatedAt  bun.NullTime `bun:",nullzero"`
+	// relationship
+	Asset 	*Asset `bun:"rel:has-one,join:asset_id=ta_asset_id"`
 }
 
 func (a *Address) BeforeAppendModel(ctx context.Context, query bun.Query) error {

--- a/db/models/address.go
+++ b/db/models/address.go
@@ -1,0 +1,28 @@
+package models
+
+import (
+	"context"
+	"time"
+	"github.com/uptrace/bun"
+)
+
+// Address : Address Model
+type Address struct {
+	ID         int64 `bun:",pk,autoincrement"`
+	Address    string `bun:",notnull,unique"`
+	UserId     int64 `bun:",notnull"`
+	AssetId	   int64 `bun:",notnull"`
+	CreatedAt  time.Time `bun:",notnull,default:current_timestamp"`
+	UpdatedAt  bun.NullTime `bun:",nullzero"`
+}
+
+func (a *Address) BeforeAppendModel(ctx context.Context, query bun.Query) error {
+	switch query.(type) {
+	case *bun.UpdateQuery:
+		a.UpdatedAt = bun.NullTime{Time: time.Now()}
+	}
+	return nil
+}
+
+var _ bun.BeforeAppendModelHook = (*Address)(nil)
+

--- a/db/models/asset.go
+++ b/db/models/asset.go
@@ -15,7 +15,7 @@ import (
 // Taproot Asset have different asset_id's.
 type Asset struct {
 	ID        int64     `bun:",pk,autoincrement"`
-	TaAssetID string    `bun:",notnull"`
+	TaAssetID string    `bun:",notnull,unique"`
 	AssetName string    `bun:",notnull,unique"`
 	AssetType int64    `bun:",notnull"` // https://lightning.engineering/api-docs/api/taproot-assets/universe/query-asset-stats#taprpcassettype
 	CreatedAt time.Time `bun:",nullzero,notnull,default:current_timestamp"`

--- a/db/models/asset.go
+++ b/db/models/asset.go
@@ -16,8 +16,8 @@ import (
 type Asset struct {
 	ID        int64     `bun:",pk,autoincrement"`
 	TaAssetID string    `bun:",notnull"`
-	AssetName string    `bun:",notnull"`
-	AssetType string    `bun:",notnull"` // https://lightning.engineering/api-docs/api/taproot-assets/universe/query-asset-stats#taprpcassettype
+	AssetName string    `bun:",notnull,unique"`
+	AssetType int64    `bun:",notnull"` // https://lightning.engineering/api-docs/api/taproot-assets/universe/query-asset-stats#taprpcassettype
 	CreatedAt time.Time `bun:",nullzero,notnull,default:current_timestamp"`
 	UpdatedAt bun.NullTime 
 }

--- a/db/models/filter.go
+++ b/db/models/filter.go
@@ -9,7 +9,7 @@ type Filter struct {
 	RelayID   int64 `bun:",pk"`
 	LastEventSeen int64 `bun:",nullzero"`
 	CreatedAt time.Time `bun:",notnull,default:current_timestamp"`
-	UpdatedAt bun.NullTime `bun:",nullzero"`
+	UpdatedAt bun.NullTime
 }
 
 func (f *Filter) BeforeAppendModel(query bun.Query) error {

--- a/db/models/invoice.go
+++ b/db/models/invoice.go
@@ -13,8 +13,8 @@ type Invoice struct {
 	Type                     string            `json:"type" validate:"required"`
 	UserID                   int64             `json:"user_id" validate:"required"`
 	User                     *User             `json:"-" bun:"rel:belongs-to,join:user_id=id"`
-	AssetID                  int64             `json:"asset_id" validate:"required"`
-	Asset                    *Asset            `json:"-" bun:"rel:has-one,join:asset_id=id"`
+	TaAssetID                string             `json:"asset_id" validate:"required"`
+	Asset                    *Asset            `json:"-" bun:"rel:has-one,join:ta_asset_id=ta_asset_id"`
 	Amount                   int64             `json:"amount" validate:"gte=0"`
 	Fee                      int64             `json:"fee"`
 	ServiceFee               int64             `json:"service_fee"`

--- a/db/models/transactionentry.go
+++ b/db/models/transactionentry.go
@@ -20,10 +20,12 @@ type TransactionEntry struct {
 	ID              int64             `bun:",pk,autoincrement"`
 	UserID          int64             `bun:",notnull"`
 	User            *User             `bun:"rel:belongs-to,join:user_id=id"`
-	InvoiceID       int64             `bun:",notnull"`
+	InvoiceID       int64             `bun:",nullzero"`
 	Invoice         *Invoice          `bun:"rel:belongs-to,join:invoice_id=id"`
 	ParentID        int64             `bun:",nullzero"`
 	Parent          *TransactionEntry `bun:"rel:belongs-to"`
+	Addr            string			  `bun:",nullzero"`
+	Address		    *Address          `bun:"rel:belongs-to,join:addr=address"`
 	CreditAccountID int64             `bun:",notnull"`
 	FeeReserve      *TransactionEntry `bun:"rel:belongs-to"`
 	ServiceFee      *TransactionEntry `bun:"rel:belongs-to"`
@@ -33,4 +35,5 @@ type TransactionEntry struct {
 	Amount          int64             `bun:",notnull"`
 	CreatedAt       time.Time         `bun:",nullzero,notnull,default:current_timestamp"`
 	EntryType       string
+	Outpoint        string 
 }

--- a/db/models/user.go
+++ b/db/models/user.go
@@ -10,6 +10,7 @@ type User struct {
 	Pubkey       string         `bun:",unique,notnull"`
 	Accounts     []*Account `bun:"rel:has-many,join:id=user_id"`
 	Invoices     []*Invoice `bun:"rel:has-many,join:id=user_id"`
+	Addresses    []*Address `bun:"rel:has-many,join:id=user_id"`
 	Deactivated  bool
 	Deleted      bool
 	CreatedAt    time.Time      `bun:",nullzero,notnull,default:current_timestamp"`

--- a/integration_tests/hodl_invoice_test.go
+++ b/integration_tests/hodl_invoice_test.go
@@ -106,7 +106,7 @@ func (suite *HodlInvoiceSuite) TestHodlInvoice() {
 	// check to see that balance was reduced
 	userId := getUserIdFromToken(suite.userToken)
 	// TODO note hard-coded asset id for now
-	userBalance, err := suite.service.CurrentUserBalance(context.Background(), 1, userId)
+	userBalance, err := suite.service.CurrentUserBalance(context.Background(), common.BTC_TA_ASSET_ID, userId)
 	if err != nil {
 		fmt.Printf("Error when getting balance %v\n", err.Error())
 	}
@@ -148,7 +148,7 @@ func (suite *HodlInvoiceSuite) TestHodlInvoice() {
 
 	// check that balance was reverted and invoice is in error state
 	// TODO note hard-coded asset id for now
-	userBalance, err = suite.service.CurrentUserBalance(context.Background(), 1, userId)
+	userBalance, err = suite.service.CurrentUserBalance(context.Background(), common.BTC_TA_ASSET_ID, userId)
 	if err != nil {
 		fmt.Printf("Error when getting balance %v\n", err.Error())
 	}
@@ -228,7 +228,7 @@ func (suite *HodlInvoiceSuite) TestHodlInvoice() {
 	}
 	//fetch user balance again
 	// TODO note hard-coded asset id for now
-	userBalance, err = suite.service.CurrentUserBalance(context.Background(), 1, userId)
+	userBalance, err = suite.service.CurrentUserBalance(context.Background(), common.BTC_TA_ASSET_ID, userId)
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), int64(userFundingSats-externalSatRequested), userBalance)
 	// check payment is updated as succesful
@@ -320,7 +320,7 @@ func (suite *HodlInvoiceSuite) TestNegativeBalanceWithHodl() {
 	})
 	//fetch user balance again
 	// TODO note hard-coded asset ID for now
-	userBalance, err := suite.service.CurrentUserBalance(context.Background(), 1, userId)
+	userBalance, err := suite.service.CurrentUserBalance(context.Background(), common.BTC_TA_ASSET_ID, userId)
 	assert.NoError(suite.T(), err)
 	//assert the balance did not go below 0
 	assert.False(suite.T(), userBalance < 0)

--- a/integration_tests/internal_payment_test.go
+++ b/integration_tests/internal_payment_test.go
@@ -301,7 +301,7 @@ func (suite *PaymentTestSuite) TestInternalPayment() {
 	// TODO this may transition to being a bitcoin specific test or, 
 	//		to handle / iterate multiple assets we include in a test environment
 	//		* asset id hard-coded for now
-	assetId := 1 // bitcoin / sats
+	assetId := common.BTC_TA_ASSET_ID // bitcoin / sats
 	aliceFundingSats := 1000
 	bobSatRequested := 500
 	// currently fee is 0 for internal payments
@@ -340,13 +340,13 @@ func (suite *PaymentTestSuite) TestInternalPayment() {
 	assert.Equal(suite.T(), http.StatusBadRequest, rec.Code)
 
 	transactionEntriesAlice, _ := suite.service.TransactionEntriesFor(context.Background(), aliceId)
-	aliceBalance, _ := suite.service.CurrentUserBalance(context.Background(), int64(assetId), aliceId)
+	aliceBalance, _ := suite.service.CurrentUserBalance(context.Background(), assetId, aliceId)
 	assert.Equal(suite.T(), 2, len(transactionEntriesAlice))
 	assert.Equal(suite.T(), int64(aliceFundingSats), transactionEntriesAlice[0].Amount)
 	assert.Equal(suite.T(), int64(bobSatRequested), transactionEntriesAlice[1].Amount)
 	assert.Equal(suite.T(), int64(aliceFundingSats-bobSatRequested-fee), aliceBalance)
 
-	bobBalance, _ := suite.service.CurrentUserBalance(context.Background(), int64(assetId), bobId)
+	bobBalance, _ := suite.service.CurrentUserBalance(context.Background(), assetId, bobId)
 	transactionEntriesBob, _ := suite.service.TransactionEntriesFor(context.Background(), bobId)
 	assert.Equal(suite.T(), 1, len(transactionEntriesBob))
 	assert.Equal(suite.T(), int64(bobSatRequested), transactionEntriesBob[0].Amount)
@@ -370,7 +370,7 @@ func (suite *PaymentTestSuite) TestInternalPayment() {
 	assert.Equal(suite.T(), http.StatusOK, rec.Code)
 	assert.NoError(suite.T(), json.NewDecoder(rec.Body).Decode(payInvoiceResponse))
 	//assert bob was credited the correct amount
-	bobBalance, _ = suite.service.CurrentUserBalance(context.Background(), int64(assetId), bobId)
+	bobBalance, _ = suite.service.CurrentUserBalance(context.Background(), assetId, bobId)
 	assert.Equal(suite.T(), int64(bobSatRequested+toPayForZeroAmt), bobBalance)
 }
 
@@ -380,7 +380,7 @@ func (suite *PaymentTestSuite) TestInternalPaymentFail() {
 	// TODO this may transition to being a bitcoin specific test or, 
 	//		to handle / iterate multiple assets we include in a test environment
 	//		* asset id hard-coded for now
-	assetId := 1 // bitcoin / sats
+	assetId := common.BTC_TA_ASSET_ID // bitcoin / sats
 	// currently fee is 0 for internal payments
 	fee := 0
 	invoiceResponse := suite.createAddInvoiceReq(aliceFundingSats, "integration test internal payment alice", suite.aliceToken)
@@ -416,7 +416,7 @@ func (suite *PaymentTestSuite) TestInternalPaymentFail() {
 		fmt.Printf("Error when getting transaction entries %v\n", err.Error())
 	}
 
-	aliceBalance, err := suite.service.CurrentUserBalance(context.Background(), int64(assetId), userId)
+	aliceBalance, err := suite.service.CurrentUserBalance(context.Background(), assetId, userId)
 	if err != nil {
 		fmt.Printf("Error when getting balance %v\n", err.Error())
 	}
@@ -438,7 +438,7 @@ func (suite *PaymentTestSuite) TestInternalPaymentKeysend() {
 	// TODO this may transition to being a bitcoin specific test or, 
 	//		to handle / iterate multiple assets we include in a test environment
 	//		* asset id hard-coded for now
-	assetId := 1 // bitcoin / sats
+	assetId := common.BTC_TA_ASSET_ID // bitcoin / sats
 	memo := "integration test internal keysend from alice"
 	invoiceResponse := suite.createAddInvoiceReq(aliceFundingSats, "integration test internal keysend alice", suite.aliceToken)
 	err := suite.mlnd.mockPaidInvoice(invoiceResponse, 0, false, nil)
@@ -449,7 +449,7 @@ func (suite *PaymentTestSuite) TestInternalPaymentKeysend() {
 
 	//check bob's balance before payment
 	bobId := getUserIdFromToken(suite.bobToken)
-	previousBobBalance, _ := suite.service.CurrentUserBalance(context.Background(), int64(assetId), bobId)
+	previousBobBalance, _ := suite.service.CurrentUserBalance(context.Background(), assetId, bobId)
 
 	//pay bob from alice using a keysend payment
 	rec := httptest.NewRecorder()
@@ -471,7 +471,7 @@ func (suite *PaymentTestSuite) TestInternalPaymentKeysend() {
 	assert.NoError(suite.T(), json.NewDecoder(rec.Body).Decode(keySendResponse))
 
 	//check bob's balance after payment
-	bobBalance, _ := suite.service.CurrentUserBalance(context.Background(), int64(assetId), bobId)
+	bobBalance, _ := suite.service.CurrentUserBalance(context.Background(), assetId, bobId)
 	assert.Equal(suite.T(), int64(bobAmt)+previousBobBalance, bobBalance)
 	//check bob's invoices for whatsat message
 	invoicesBob, _ := suite.service.InvoicesFor(context.Background(), bobId, common.InvoiceTypeIncoming)

--- a/integration_tests/keysend_failure_test.go
+++ b/integration_tests/keysend_failure_test.go
@@ -97,7 +97,7 @@ func (suite *KeySendFailureTestSuite) TestKeysendPayment() {
 	// check that balance was reverted
 	userId := getUserIdFromToken(suite.aliceToken)
 	// TODO hard-code asset ID for now
-	aliceBalance, err := suite.service.CurrentUserBalance(context.Background(), 1, userId)
+	aliceBalance, err := suite.service.CurrentUserBalance(context.Background(), common.BTC_TA_ASSET_ID, userId)
 	if err != nil {
 		fmt.Printf("Error when getting balance %v\n", err.Error())
 	}

--- a/integration_tests/keysend_test.go
+++ b/integration_tests/keysend_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/getAlby/lndhub.go/common"
 	"github.com/getAlby/lndhub.go/controllers"
 	v2controllers "github.com/getAlby/lndhub.go/controllers_v2"
 	"github.com/getAlby/lndhub.go/lib"
@@ -94,7 +95,7 @@ func (suite *KeySendTestSuite) TestKeysendPayment() {
 	// check that balance was reduced
 	userId := getUserIdFromToken(suite.aliceToken)
 	// TODO hard-code asset id for now
-	aliceBalance, err := suite.service.CurrentUserBalance(context.Background(), 1, userId)
+	aliceBalance, err := suite.service.CurrentUserBalance(context.Background(), common.BTC_TA_ASSET_ID, userId)
 	if err != nil {
 		fmt.Printf("Error when getting balance %v\n", err.Error())
 	}
@@ -157,7 +158,7 @@ func (suite *KeySendTestSuite) TestMultiKeysend() {
 	//check that balance was reduced appropriately
 	userId := getUserIdFromToken(suite.aliceToken)
 	// TODO hard-code asset ID for now
-	aliceBalance, err := suite.service.CurrentUserBalance(context.Background(), 1, userId)
+	aliceBalance, err := suite.service.CurrentUserBalance(context.Background(), common.BTC_TA_ASSET_ID, userId)
 	if err != nil {
 		fmt.Printf("Error when getting balance %v\n", err.Error())
 	}

--- a/integration_tests/outgoing_payment_test.go
+++ b/integration_tests/outgoing_payment_test.go
@@ -23,7 +23,7 @@ func (suite *PaymentTestSuite) TestOutGoingPayment() {
 	// TODO this may transition to being a bitcoin specific test or, 
 	//		to handle / iterate multiple assets we include in a test environment
 	//		* asset id hard-coded for now
-	assetId := 1 // bitcoin / sats
+	assetId := common.BTC_TA_ASSET_ID // bitcoin / sats
 	//fund alice account
 	invoiceResponse := suite.createAddInvoiceReq(aliceFundingSats, "integration test external payment alice", suite.aliceToken)
 	err := suite.mlnd.mockPaidInvoice(invoiceResponse, 0, false, nil)
@@ -47,7 +47,7 @@ func (suite *PaymentTestSuite) TestOutGoingPayment() {
 
 	// check that balance was reduced
 	userId := getUserIdFromToken(suite.aliceToken)
-	aliceBalance, err := suite.service.CurrentUserBalance(context.Background(), int64(assetId), userId)
+	aliceBalance, err := suite.service.CurrentUserBalance(context.Background(), assetId, userId)
 	if err != nil {
 		fmt.Printf("Error when getting balance %v\n", err.Error())
 	}
@@ -59,10 +59,10 @@ func (suite *PaymentTestSuite) TestOutGoingPayment() {
 		fmt.Printf("Error when getting transaction entries %v\n", err.Error())
 	}
 	// verify transaction entries data
-	feeAccount, _ := suite.service.AccountFor(context.Background(), common.AccountTypeFees, int64(assetId), userId)
-	incomingAccount, _ := suite.service.AccountFor(context.Background(), common.AccountTypeIncoming, int64(assetId), userId)
-	outgoingAccount, _ := suite.service.AccountFor(context.Background(), common.AccountTypeOutgoing, int64(assetId), userId)
-	currentAccount, _ := suite.service.AccountFor(context.Background(), common.AccountTypeCurrent, int64(assetId), userId)
+	feeAccount, _ := suite.service.AccountFor(context.Background(), common.AccountTypeFees, assetId, userId)
+	incomingAccount, _ := suite.service.AccountFor(context.Background(), common.AccountTypeIncoming, assetId, userId)
+	outgoingAccount, _ := suite.service.AccountFor(context.Background(), common.AccountTypeOutgoing, assetId, userId)
+	currentAccount, _ := suite.service.AccountFor(context.Background(), common.AccountTypeCurrent, assetId, userId)
 
 	outgoingInvoices, _ := suite.service.InvoicesFor(context.Background(), userId, common.InvoiceTypeOutgoing)
 	incomingInvoices, _ := suite.service.InvoicesFor(context.Background(), userId, common.InvoiceTypeIncoming)
@@ -140,7 +140,7 @@ func (suite *PaymentTestSuite) TestOutGoingPaymentWithNegativeBalance() {
 	// TODO this may transition to being a bitcoin specific test or, 
 	//		to handle / iterate multiple assets we include in a test environment
 	//		* asset id hard-coded for now
-	assetId := 1 // bitcoin / sats
+	assetId := common.BTC_TA_ASSET_ID // bitcoin / sats
 	//fund alice account
 	invoiceResponse := suite.createAddInvoiceReq(aliceFundingSats, "integration test external payment alice", suite.aliceToken)
 	err := suite.mlnd.mockPaidInvoice(invoiceResponse, 0, false, nil)
@@ -164,7 +164,7 @@ func (suite *PaymentTestSuite) TestOutGoingPaymentWithNegativeBalance() {
 	// check that balance was reduced
 	userId := getUserIdFromToken(suite.aliceToken)
 
-	aliceBalance, err := suite.service.CurrentUserBalance(context.Background(), int64(assetId), userId)
+	aliceBalance, err := suite.service.CurrentUserBalance(context.Background(), assetId, userId)
 	if err != nil {
 		fmt.Printf("Error when getting balance %v\n", err.Error())
 	}
@@ -177,10 +177,10 @@ func (suite *PaymentTestSuite) TestOutGoingPaymentWithNegativeBalance() {
 		fmt.Printf("Error when getting transaction entries %v\n", err.Error())
 	}
 	// verify transaction entries data
-	feeAccount, _ := suite.service.AccountFor(context.Background(), common.AccountTypeFees, int64(assetId), userId)
-	incomingAccount, _ := suite.service.AccountFor(context.Background(), common.AccountTypeIncoming, int64(assetId), userId)
-	outgoingAccount, _ := suite.service.AccountFor(context.Background(), common.AccountTypeOutgoing, int64(assetId), userId)
-	currentAccount, _ := suite.service.AccountFor(context.Background(), common.AccountTypeCurrent, int64(assetId), userId)
+	feeAccount, _ := suite.service.AccountFor(context.Background(), common.AccountTypeFees, assetId, userId)
+	incomingAccount, _ := suite.service.AccountFor(context.Background(), common.AccountTypeIncoming, assetId, userId)
+	outgoingAccount, _ := suite.service.AccountFor(context.Background(), common.AccountTypeOutgoing, assetId, userId)
+	currentAccount, _ := suite.service.AccountFor(context.Background(), common.AccountTypeCurrent, assetId, userId)
 
 	outgoingInvoices, _ := suite.service.InvoicesFor(context.Background(), userId, common.InvoiceTypeOutgoing)
 	incomingInvoices, _ := suite.service.InvoicesFor(context.Background(), userId, common.InvoiceTypeIncoming)

--- a/integration_tests/payment_failure_async_test.go
+++ b/integration_tests/payment_failure_async_test.go
@@ -81,7 +81,7 @@ func (suite *PaymentTestAsyncErrorsSuite) TestExternalAsyncFailingInvoice() {
 	// TODO this may transition to being a bitcoin specific test or, 
 	//		to handle / iterate multiple assets we include in a test environment
 	//		* asset id hard-coded for now
-	assetId := 1 // bitcoin / sats
+	assetId := common.BTC_TA_ASSET_ID // bitcoin / sats
 	// fund user account
 	invoiceResponse := suite.createAddInvoiceReq(userFundingSats, "integration test external payment user", suite.userToken)
 	err := suite.mlnd.mockPaidInvoice(invoiceResponse, 0, false, nil)
@@ -105,7 +105,7 @@ func (suite *PaymentTestAsyncErrorsSuite) TestExternalAsyncFailingInvoice() {
 
 	// check to see that balance was reduced
 	userId := getUserIdFromToken(suite.userToken)
-	userBalance, err := suite.service.CurrentUserBalance(context.Background(), int64(assetId), userId)
+	userBalance, err := suite.service.CurrentUserBalance(context.Background(), assetId, userId)
 	if err != nil {
 		fmt.Printf("Error when getting balance %v\n", err.Error())
 	}
@@ -117,7 +117,7 @@ func (suite *PaymentTestAsyncErrorsSuite) TestExternalAsyncFailingInvoice() {
 	time.Sleep(2 * time.Second)
 
 	// check that balance was reverted and invoice is in error state
-	userBalance, err = suite.service.CurrentUserBalance(context.Background(), int64(assetId), userId)
+	userBalance, err = suite.service.CurrentUserBalance(context.Background(), assetId, userId)
 	if err != nil {
 		fmt.Printf("Error when getting balance %v\n", err.Error())
 	}

--- a/integration_tests/payment_failure_test.go
+++ b/integration_tests/payment_failure_test.go
@@ -85,7 +85,7 @@ func (suite *PaymentTestErrorsSuite) TestExternalFailingInvoice() {
 	// TODO this may transition to being a bitcoin specific test or, 
 	//		to handle / iterate multiple assets we include in a test environment
 	//		* asset id hard-coded for now
-	assetId := 1 // bitcoin / sats
+	assetId := common.BTC_TA_ASSET_ID // bitcoin / sats
 	//fund user account
 	invoiceResponse := suite.createAddInvoiceReq(userFundingSats, "integration test external payment user", suite.userToken)
 	err := suite.mlnd.mockPaidInvoice(invoiceResponse, 0, false, nil)
@@ -137,10 +137,10 @@ func (suite *PaymentTestErrorsSuite) TestExternalFailingInvoice() {
 	userId := getUserIdFromToken(suite.userToken)
 
 	// verify transaction entries data
-	feeAccount, _ := suite.service.AccountFor(context.Background(), common.AccountTypeFees, int64(assetId), userId)
-	incomingAccount, _ := suite.service.AccountFor(context.Background(), common.AccountTypeIncoming, int64(assetId), userId)
-	outgoingAccount, _ := suite.service.AccountFor(context.Background(), common.AccountTypeOutgoing, int64(assetId), userId)
-	currentAccount, _ := suite.service.AccountFor(context.Background(), common.AccountTypeCurrent, int64(assetId), userId)
+	feeAccount, _ := suite.service.AccountFor(context.Background(), common.AccountTypeFees, assetId, userId)
+	incomingAccount, _ := suite.service.AccountFor(context.Background(), common.AccountTypeIncoming, assetId, userId)
+	outgoingAccount, _ := suite.service.AccountFor(context.Background(), common.AccountTypeOutgoing, assetId, userId)
+	currentAccount, _ := suite.service.AccountFor(context.Background(), common.AccountTypeCurrent, assetId, userId)
 
 	outgoingInvoices, err := invoicesFor(suite.service, userId, common.InvoiceTypeOutgoing)
 	if err != nil {
@@ -159,7 +159,7 @@ func (suite *PaymentTestErrorsSuite) TestExternalFailingInvoice() {
 		fmt.Printf("Error when getting transaction entries %v\n", err.Error())
 	}
 
-	userBalance, err := suite.service.CurrentUserBalance(context.Background(), int64(assetId), userId)
+	userBalance, err := suite.service.CurrentUserBalance(context.Background(), assetId, userId)
 	if err != nil {
 		fmt.Printf("Error when getting balance %v\n", err.Error())
 	}

--- a/lib/responses/errors.go
+++ b/lib/responses/errors.go
@@ -112,6 +112,13 @@ var AccountDeactivatedError = ErrorResponse{
 	HttpStatusCode: 401,
 }
 
+var NoBytesWrittenError = ErrorResponse{
+	Error:          true,
+	Code:           2,
+	Message:        "no bytes written",
+	HttpStatusCode: 500,
+}
+
 var UnimplementedError = ErrorResponse{
 	Error: true,
 	Code: 999,

--- a/lib/service/address.go
+++ b/lib/service/address.go
@@ -1,0 +1,49 @@
+package service
+
+import (
+	"context"
+	"github.com/getAlby/lndhub.go/db/models"
+)
+
+func (svc *LndhubService) CreateAddress(ctx context.Context, address string, userId int64, assetId int64) (addr *models.Address, err error) {
+	addr = &models.Address{}
+	addr.Address = address
+	addr.UserId = userId
+	addr.AssetId = assetId
+
+	_, err = svc.DB.NewInsert().Model(addr).Exec(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return addr, nil
+}
+
+func (svc * LndhubService) UpdateAddress(ctx context.Context, assetId int64, userId int64, address string) (addr *models.Address, err error) {
+	addr, err = svc.FindAddress(ctx, userId, assetId)
+	if err != nil {
+		return nil, err
+	}
+	addr.Address = address
+	_, err = svc.DB.NewUpdate().Model(addr).WherePK().Exec(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return addr, nil
+}
+
+func (svc *LndhubService) GetAddresses(ctx context.Context, userId int64) ([]models.Address, error) {
+	addr := []models.Address{}
+
+	err := svc.DB.NewSelect().Model(&addr).Where("user_id = ?", userId).Distinct().Scan(ctx)
+	return addr, err
+}
+
+func (svc *LndhubService) FindAddress(ctx context.Context, userId int64, assetId int64) (*models.Address, error) {
+	var addr models.Address
+
+	err := svc.DB.NewSelect().Model(&addr).Where("user_id = ? AND asset_id = ?", userId, assetId).Limit(1).Scan(ctx)
+	if err != nil {
+		return &addr, err
+	}
+	return &addr, nil
+}

--- a/lib/service/address.go
+++ b/lib/service/address.go
@@ -2,16 +2,34 @@ package service
 
 import (
 	"context"
+	//"encoding/hex"
+	//"errors"
+
 	"github.com/getAlby/lndhub.go/db/models"
 )
 
-func (svc *LndhubService) CreateAddress(ctx context.Context, address string, userId uint64, taAssetId string) (addr *models.Address, err error) {
-	addr = &models.Address{}
-	addr.Address = address
-	addr.UserId = userId
-	addr.TaAssetID = taAssetId
+type AddressResponse struct {
+	AssetName  string `json:"asset_name"`
+	TaAssetID  string `json:"ta_asset_id"`
+	Addr       string `json:"addr"`  
+}
 
-	_, err = svc.DB.NewInsert().Model(addr).Exec(ctx)
+
+func (svc *LndhubService) CreateAddress(ctx context.Context, address string, userId uint64, taAssetId string, amt uint64) (addr *models.Address, err error) {
+	addrObj := &models.Address{}
+	// encAddr := make([]byte, hex.EncodedLen(len(address)))
+	// // hex encode address for sql length issue
+	// val := hex.Encode(encAddr, []byte(address))
+	// // if wrote 0 bytes, return error
+	// if val == 0 {
+	// 	return nil, err
+	// }
+	addrObj.Addr = address
+	addrObj.UserId = userId
+	addrObj.TaAssetID = taAssetId
+	addrObj.Amount = amt
+
+	_, err = svc.DB.NewInsert().Model(addrObj).Exec(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -20,10 +38,23 @@ func (svc *LndhubService) CreateAddress(ctx context.Context, address string, use
 
 func (svc * LndhubService) UpdateAddress(ctx context.Context, taAssetId string, userId uint64, address string, amt uint64) (addr *models.Address, err error) {
 	addr, err = svc.FindAddress(ctx, userId, taAssetId, amt)
+	// check error
 	if err != nil {
 		return nil, err
 	}
-	addr.Address = address
+	// check not found (this is likely redundant to the first check)
+	if addr == nil {
+		return nil, nil
+	}
+	// var encAddr []byte
+	// // hex encode address for sql length issue
+	// val := hex.Encode(encAddr, []byte(address))
+	// // if wrote 0 bytes, return error
+	// if val == 0 {
+	// 	return nil, err
+	// }
+	addr.Addr   = address
+	addr.Amount = amt
 	_, err = svc.DB.NewUpdate().Model(addr).WherePK().Exec(ctx)
 	if err != nil {
 		return nil, err
@@ -32,10 +63,38 @@ func (svc * LndhubService) UpdateAddress(ctx context.Context, taAssetId string, 
 }
 
 func (svc *LndhubService) GetAddresses(ctx context.Context, userId uint64) ([]models.Address, error) {
-	addr := []models.Address{}
+	/// NOTE: THIS DOES THE HEX DECODE
+	addresses := []models.Address{}
+	//response  := []AddressResponse{}
 
-	err := svc.DB.NewSelect().Model(&addr).Where("user_id = ?", userId).Distinct().Scan(ctx)
-	return addr, err
+	// get all addresses for user
+	err := svc.DB.NewSelect().Model(&addresses).Where("user_id = ?", userId).Distinct().Scan(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO use bulk helper here
+	// for _, addr := range addresses {
+	// 	// decode address
+	// 	var decodedAddr []byte
+	// 	_, err := hex.Decode(decodedAddr, addr.Addr)
+	// 	if err != nil {
+	// 		return nil, err
+	// 	}
+	// 	// convert address bytes to string
+	// 	decodedAddrStr := string(decodedAddr)
+	// 	// create AddressResponse object for the address
+	// 	addrResp := AddressResponse{
+	// 		AssetName: addr.Asset.AssetName,
+	// 		TaAssetID: addr.TaAssetID,
+	// 		Addr: addr.Addr,
+	// 	}
+	// 	// append to result set
+	// 	response = append(response, addrResp)
+	// }
+	//return response, err
+
+	return addresses, err
 }
 
 func (svc *LndhubService) FindAddress(ctx context.Context, userId uint64, taAssetId string, amt uint64) (*models.Address, error) {
@@ -43,8 +102,58 @@ func (svc *LndhubService) FindAddress(ctx context.Context, userId uint64, taAsse
 
 	err := svc.DB.NewSelect().Model(&addr).Where("user_id = ? AND amount = ? AND ta_asset_id = ?", userId, amt, taAssetId).Limit(1).Scan(ctx)
 	if err != nil {
+		if err.Error() == "sql: no rows in result set" {
+			return nil, nil
+		}
+		// sql error or not found
 		return &addr, err
 	}
-
+	// success
 	return &addr, nil
 }
+
+// func decodedAddresses(addresses []models.Address) ([]AddressResponse, error) {
+// 	response := []AddressResponse{}
+// 	// TODO decode all addresses - look for more efficient way to do this
+// 	for _, addr := range addresses {
+// 		// decode address
+// 		var decodedAddr []byte
+// 		_, err := hex.Decode(decodedAddr, addr.Addr)
+// 		if err != nil {
+// 			return nil, err
+// 		}
+// 		// convert address bytes to string
+// 		decodedAddrStr := string(decodedAddr)
+// 		// create AddressResponse object for the address
+// 		addrResp := AddressResponse{
+// 			AssetName: addr.Asset.AssetName,
+// 			TaAssetID: addr.TaAssetID,
+// 			Addr: decodedAddrStr,
+// 		}
+// 		// append to result set
+// 		response = append(response, addrResp)
+// 	}
+// 	return response, nil
+// }
+
+// func decodeDbAddressToString(address []byte) (string, error) {
+// 	var decodedAddr []byte
+// 	_, err := hex.Decode(decodedAddr, address)
+// 	if err != nil {
+// 		return string(decodedAddr), err
+// 	}
+// 	// convert address bytes to string
+// 	decodedAddrStr := string(decodedAddr)
+// 	return decodedAddrStr, nil
+// }
+
+// func encodeDbAddressHex(address string) ([]byte, error) {
+// 	var encAddr []byte
+// 	// hex encode address for sql length issue
+// 	val := hex.Encode(encAddr, []byte(address))
+// 	// if wrote 0 bytes, return error
+// 	if val == 0 {
+// 		return encAddr, errors.New("no bytes written")
+// 	}
+// 	return encAddr, nil
+// }

--- a/lib/service/address.go
+++ b/lib/service/address.go
@@ -5,11 +5,11 @@ import (
 	"github.com/getAlby/lndhub.go/db/models"
 )
 
-func (svc *LndhubService) CreateAddress(ctx context.Context, address string, userId int64, assetId int64) (addr *models.Address, err error) {
+func (svc *LndhubService) CreateAddress(ctx context.Context, address string, userId uint64, taAssetId string) (addr *models.Address, err error) {
 	addr = &models.Address{}
 	addr.Address = address
 	addr.UserId = userId
-	addr.AssetId = assetId
+	addr.TaAssetID = taAssetId
 
 	_, err = svc.DB.NewInsert().Model(addr).Exec(ctx)
 	if err != nil {
@@ -18,8 +18,8 @@ func (svc *LndhubService) CreateAddress(ctx context.Context, address string, use
 	return addr, nil
 }
 
-func (svc * LndhubService) UpdateAddress(ctx context.Context, assetId int64, userId int64, address string) (addr *models.Address, err error) {
-	addr, err = svc.FindAddress(ctx, userId, assetId)
+func (svc * LndhubService) UpdateAddress(ctx context.Context, taAssetId string, userId uint64, address string, amt uint64) (addr *models.Address, err error) {
+	addr, err = svc.FindAddress(ctx, userId, taAssetId, amt)
 	if err != nil {
 		return nil, err
 	}
@@ -31,19 +31,20 @@ func (svc * LndhubService) UpdateAddress(ctx context.Context, assetId int64, use
 	return addr, nil
 }
 
-func (svc *LndhubService) GetAddresses(ctx context.Context, userId int64) ([]models.Address, error) {
+func (svc *LndhubService) GetAddresses(ctx context.Context, userId uint64) ([]models.Address, error) {
 	addr := []models.Address{}
 
 	err := svc.DB.NewSelect().Model(&addr).Where("user_id = ?", userId).Distinct().Scan(ctx)
 	return addr, err
 }
 
-func (svc *LndhubService) FindAddress(ctx context.Context, userId int64, assetId int64) (*models.Address, error) {
+func (svc *LndhubService) FindAddress(ctx context.Context, userId uint64, taAssetId string, amt uint64) (*models.Address, error) {
 	var addr models.Address
 
-	err := svc.DB.NewSelect().Model(&addr).Where("user_id = ? AND asset_id = ?", userId, assetId).Limit(1).Scan(ctx)
+	err := svc.DB.NewSelect().Model(&addr).Where("user_id = ? AND amount = ? AND ta_asset_id = ?", userId, amt, taAssetId).Limit(1).Scan(ctx)
 	if err != nil {
 		return &addr, err
 	}
+
 	return &addr, nil
 }

--- a/lib/service/asset.go
+++ b/lib/service/asset.go
@@ -2,7 +2,10 @@ package service
 
 import (
 	"context"
+	"encoding/hex"
+	b64 "encoding/base64"
 	"github.com/getAlby/lndhub.go/db/models"
+	"github.com/lightninglabs/taproot-assets/taprpc"
 )
 
 func (svc *LndhubService) CreateAsset(ctx context.Context, name string, tapdAssetId string, tapdAssetType int64) (asset *models.Asset, err error) {
@@ -57,3 +60,12 @@ func (svc *LndhubService) UpdateAsset(ctx context.Context, assetId int64) (asset
 	return asset, nil
 }
 
+func decodeAssetIdBytes(address *taprpc.Addr) (string, error) {
+	// hex decode the raw asset id bytes
+	decoded, err := hex.DecodeString(address.Encoded)
+	if err != nil {
+		return "", err
+	}
+	// then encode the hex format asset id to base64
+	return b64.StdEncoding.EncodeToString(decoded), nil
+}

--- a/lib/service/asset.go
+++ b/lib/service/asset.go
@@ -1,0 +1,59 @@
+package service
+
+import (
+	"context"
+	"github.com/getAlby/lndhub.go/db/models"
+)
+
+func (svc *LndhubService) CreateAsset(ctx context.Context, name string, tapdAssetId string, tapdAssetType int64) (asset *models.Asset, err error) {
+	asset = &models.Asset{}
+	asset.AssetName = name
+	asset.TaAssetID = tapdAssetId
+	asset.AssetType = tapdAssetType
+	
+	_, err = svc.DB.NewInsert().Model(asset).Exec(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return asset, nil
+}
+
+func (svc *LndhubService) GetAssets(ctx context.Context) ([]models.Asset, error) {
+	asset := []models.Asset{}
+
+	err := svc.DB.NewSelect().Model(&asset).Distinct().Scan(ctx)
+	return asset, err
+}
+
+func (svc *LndhubService) FindAsset(ctx context.Context, assetId int64) (*models.Asset, error) {
+	var asset models.Asset
+
+	err := svc.DB.NewSelect().Model(&asset).Where("id = ?", assetId).Limit(1).Scan(ctx)
+	if err != nil {
+		return &asset, err
+	}
+	return &asset, nil
+}
+
+func (svc *LndhubService) FindAssetByName(ctx context.Context, assetName string) (*models.Asset, error) {
+	var asset models.Asset
+
+	err := svc.DB.NewSelect().Model(&asset).Where("name = ?", assetName).Limit(1).Scan(ctx)
+	if err != nil {
+		return &asset, err
+	}
+	return &asset, nil
+}
+
+func (svc *LndhubService) UpdateAsset(ctx context.Context, assetId int64) (asset *models.Asset, err error) {
+	asset, err = svc.FindAsset(ctx, assetId)
+	if err != nil {
+		return nil, err
+	}
+	_, err = svc.DB.NewUpdate().Model(asset).WherePK().Exec(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return asset, nil
+}
+

--- a/lib/service/background_routines.go
+++ b/lib/service/background_routines.go
@@ -63,6 +63,17 @@ func (svc *LndhubService) StartRelayRoutine(ctx context.Context, uri string, las
 	return nil
 }
 
+func (svc *LndhubService) StartReceiveSubscription(ctx context.Context, url string) (err error) {
+	// TODO what is the proper way to not have a timeout on the context?
+	if svc.RabbitMQClient != nil {
+		// TODO populate
+		return nil
+	} else {
+		// TODO populate
+		return nil
+	}
+}
+
 func (svc *LndhubService) StartInvoiceRoutine(ctx context.Context) (err error) {
 	if svc.RabbitMQClient != nil {
 		err = svc.RabbitMQClient.SubscribeToLndInvoices(ctx, svc.ProcessInvoiceUpdate)

--- a/lib/service/background_routines.go
+++ b/lib/service/background_routines.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	//"time"
@@ -63,13 +64,18 @@ func (svc *LndhubService) StartRelayRoutine(ctx context.Context, uri string, las
 	return nil
 }
 
-func (svc *LndhubService) StartReceiveSubscription(ctx context.Context, url string) (err error) {
+func (svc *LndhubService) StartReceiveSubscription(ctx context.Context) (err error) {
 	// TODO what is the proper way to not have a timeout on the context?
 	if svc.RabbitMQClient != nil {
-		// TODO populate
-		return nil
+		// TODO populate - apply sentry and rabbit mq
+		return errors.New("RabbitMQ not implemented")
 	} else {
-		// TODO populate
+		err = svc.TapdReceiveSubscription(ctx)
+		if err != nil && err != context.Canceled {
+			// in case of an error in this routine, we want to restart
+			return err
+		}
+
 		return nil
 	}
 }

--- a/lib/service/event.go
+++ b/lib/service/event.go
@@ -113,11 +113,18 @@ func (svc *LndhubService) EventHandler(ctx context.Context, payload nostr.Event,
 			svc.Logger.Errorf("Failed to parse amt field in content: %v", err)
 			return svc.RespondToNip4(ctx, "error: failed to parse amt", true, decoded.PubKey, decoded.ID, relayUri, lastSeen)
 		}
+		// * TODO check asset table for existing asset 
+
+		// * TODO check address table for existing address, for requested asset
+
+		// create address if one is not found
 		msg, status := svc.GetAddressByAssetId(ctx, assetId, amt)
 		if !status {
 			svc.Logger.Errorf("Failed to get rcv address for asset from tapd: %s", msg)
 			return svc.RespondToNip4(ctx, "error: failed to get rcv address", true, decoded.PubKey, decoded.ID, relayUri, lastSeen)
 		}
+		// * TODO if address is new, insert it into the address table
+
 		// respond to client
 		return svc.RespondToNip4(ctx, msg, false, decoded.PubKey, decoded.ID, relayUri, decoded.CreatedAt.Time().Unix())
 	} else {

--- a/lib/service/invoicesubscription.go
+++ b/lib/service/invoicesubscription.go
@@ -109,13 +109,13 @@ func (svc *LndhubService) ProcessInvoiceUpdate(ctx context.Context, rawInvoice *
 	svc.Logger.Infof("Invoice update: invoice_id:%v settled:%v value:%v state:%v", invoice.ID, rawInvoice.Settled, rawInvoice.AmtPaidSat, rawInvoice.State)
 
 	// Get the user's current account for the transaction entry
-	creditAccount, err := svc.AccountFor(ctx, common.AccountTypeCurrent, invoice.AssetID, invoice.UserID)
+	creditAccount, err := svc.AccountFor(ctx, common.AccountTypeCurrent, invoice.TaAssetID, invoice.UserID)
 	if err != nil {
 		svc.Logger.Errorf("Could not find current account user_id:%v invoice_id:%v", invoice.UserID, invoice.ID)
 		return err
 	}
 	// Get the user's incoming account for the transaction entry
-	debitAccount, err := svc.AccountFor(ctx, common.AccountTypeIncoming, invoice.AssetID, invoice.UserID)
+	debitAccount, err := svc.AccountFor(ctx, common.AccountTypeIncoming, invoice.TaAssetID, invoice.UserID)
 	if err != nil {
 		svc.Logger.Errorf("Could not find incoming account user_id:%v invoice_id:%v", invoice.UserID, invoice.ID)
 		return err

--- a/lib/service/receivesubscription.go
+++ b/lib/service/receivesubscription.go
@@ -16,6 +16,59 @@ func (svc *LndhubService) ConnectReceiveSubscription(ctx context.Context) (tapd.
 	return svc.TapdClient.SubscribeReceiveAssetEvent(ctx, &taprpc.SubscribeReceiveAssetEventNtfnsRequest{})
 }
 
-func (svc *LndhubService) HandleTapdReceiveEvent(ctx context.Context) (err error) {
+func (svc *LndhubService) TapdReceiveSubscription(ctx context.Context) (err error) {
+	rcvSubscriptionStream, err := svc.ConnectReceiveSubscription(ctx)
+	if err != nil {
+		// TODO apply sentry
+		return err
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			// receive event
+			rcvEvent, err := rcvSubscriptionStream.Recv()
+			if err != nil {
+				// TODO apply sentry
+				return err
+			}
+			// handle event
+			err = svc.HandleTapdReceiveEvent(ctx, rcvEvent)
+			if err != nil {
+				// TODO apply sentry
+				return err
+			}
+		}
+	}
+}
 
+func (svc *LndhubService) HandleTapdReceiveEvent(ctx context.Context, rcvEvent *taprpc.ReceiveAssetEvent) (err error) {
+	// check backoff first
+	backoffEvent := rcvEvent.GetProofTransferBackoffWaitEvent()
+	if backoffEvent.TriesCounter > 0 {
+		// TODO something is going wrong
+		svc.Logger.Error("backoff event received")
+		// TODO apply sentry
+		return nil
+	}
+	// check complete event
+	completeEvent := rcvEvent.GetAssetReceiveCompleteEvent()
+	// TODO could this be null
+	if completeEvent.Timestamp > 0 {
+		// TODO confirm this is the best indication the event has been processed
+
+		// TODO create current account entry
+		
+		// event is completed
+	}
+
+
+	// TODO check if event has already been processed
+	// if err != nil {
+	// 	return err
+	// }
+	// process event
+	// TODO process event
+	return nil
 }

--- a/lib/service/receivesubscription.go
+++ b/lib/service/receivesubscription.go
@@ -1,0 +1,11 @@
+package service
+
+import (
+	"errors"
+	//"github.com/lightninglabs/taproot-assets/taprpc"
+)
+
+var AlreadyProcessedTapdEventError = errors.New("already processed tapd event")
+// * TODO insert receive addresses for user as they request them
+
+// * TODO find user by receive address

--- a/lib/service/receivesubscription.go
+++ b/lib/service/receivesubscription.go
@@ -3,7 +3,10 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
 
+	"github.com/getAlby/lndhub.go/common"
+	"github.com/getAlby/lndhub.go/db/models"
 	"github.com/getAlby/lndhub.go/tapd"
 	"github.com/lightninglabs/taproot-assets/taprpc"
 )
@@ -52,23 +55,72 @@ func (svc *LndhubService) HandleTapdReceiveEvent(ctx context.Context, rcvEvent *
 		// TODO apply sentry
 		return nil
 	}
+
 	// check complete event
 	completeEvent := rcvEvent.GetAssetReceiveCompleteEvent()
-	// TODO could this be null
-	if completeEvent.Timestamp > 0 {
-		// TODO confirm this is the best indication the event has been processed
-
-		// TODO create current account entry
-		
-		// event is completed
+	// get user by address
+	tahubUser, err := svc.FindUserByAddress(ctx, completeEvent.Address.Encoded)
+	if err != nil {
+		svc.Logger.Error("error finding user by address")
+		// TODO apply sentry
+		return err
+	}
+	svc.Logger.Infof("tahub user found: %s", tahubUser.Pubkey)
+	// decode the asset id
+	assetId, err := decodeAssetIdBytes(completeEvent.Address)
+	if err != nil {
+		svc.Logger.Error("error decoding asset id")
+		// TODO apply sentry
+		return err
+	}
+	svc.Logger.Infof("asset id decoded: %s", assetId)
+	// get user incoming account (it will go negative which is acceptable per notes in db migration)
+	// - this will be the debit_account
+	debitAccount, err := svc.AccountFor(ctx, common.AccountTypeIncoming, assetId, tahubUser.ID)
+	if err != nil {
+		svc.Logger.Error("error getting user incoming account")
+		// TODO apply sentry
+		return err
+	}
+	// get user current account
+	// - this will be the credit_account
+	creditAccount, err := svc.AccountFor(ctx, common.AccountTypeCurrent, assetId, tahubUser.ID)
+	if err != nil {
+		svc.Logger.Error("error getting user current account")
+		// TODO apply sentry
+		return err
+	}
+	// 	transaction entry
+	entry := models.TransactionEntry{
+		UserID: tahubUser.ID,
+		DebitAccountID: debitAccount.ID,
+		CreditAccountID: creditAccount.ID,
+		Amount: int64(completeEvent.Address.Amount),
+		EntryType: models.EntryTypeIncoming,
+		Outpoint: completeEvent.Outpoint,
+		Addr: completeEvent.Address.Encoded,
 	}
 
+	if completeEvent.Timestamp > 0 {
+		// TODO ensure that completed Event is always populated even if backoff is too
+		// TODO confirm this is the best indication the event has been processed
 
-	// TODO check if event has already been processed
-	// if err != nil {
-	// 	return err
-	// }
-	// process event
-	// TODO process event
+		// insert the tx entry
+		_, err = svc.DB.NewInsert().Model(&entry).Exec(ctx)
+		// check error on insertion
+		if err != nil {
+			svc.Logger.Error("error inserting transaction entry")
+			// TODO apply sentry
+			return err
+		}
+		// create message
+		message := "received: " + completeEvent.Address.Encoded + " " + fmt.Sprint(completeEvent.Address.Amount) + " " + assetId
+		// broadcast the notice to the user
+        _ = svc.SendNip4Notification(ctx, message, tahubUser.Pubkey)
+	} else {
+		// TODO what is this condition?
+		// TODO apply sentry
+		svc.Logger.Error("event not completed, execution path needs exploration")
+	}
 	return nil
 }

--- a/lib/service/receivesubscription.go
+++ b/lib/service/receivesubscription.go
@@ -53,7 +53,7 @@ func (svc *LndhubService) HandleTapdReceiveEvent(ctx context.Context, rcvEvent *
 		// TODO something is going wrong
 		svc.Logger.Error("backoff event received")
 		// TODO apply sentry
-		return nil
+		//return nil
 	}
 
 	// check complete event

--- a/lib/service/receivesubscription.go
+++ b/lib/service/receivesubscription.go
@@ -1,11 +1,21 @@
 package service
 
 import (
+	"context"
 	"errors"
-	//"github.com/lightninglabs/taproot-assets/taprpc"
+
+	"github.com/getAlby/lndhub.go/tapd"
+	"github.com/lightninglabs/taproot-assets/taprpc"
 )
 
 var AlreadyProcessedTapdEventError = errors.New("already processed tapd event")
-// * TODO insert receive addresses for user as they request them
 
-// * TODO find user by receive address
+func (svc *LndhubService) ConnectReceiveSubscription(ctx context.Context) (tapd.SubscribeReceiveAssetEventWrapper, error) {
+	// start tapd receive asset subcription
+	svc.Logger.Info("starting tapd receive asset subscription")
+	return svc.TapdClient.SubscribeReceiveAssetEvent(ctx, &taprpc.SubscribeReceiveAssetEventNtfnsRequest{})
+}
+
+func (svc *LndhubService) HandleTapdReceiveEvent(ctx context.Context) (err error) {
+
+}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -149,7 +149,7 @@ func (svc *LndhubService) CheckEvent(payload nostr.Event) (bool, nostr.Event, er
 
 }
 
-func (svc *LndhubService) OneAssetInMultiKeysend(arr []int64) bool {
+func (svc *LndhubService) OneAssetInMultiKeysend(arr []string) bool {
 	for i := 1; i < len(arr); i++ {
 		// compare every item to the first positioned item
 		if arr[i] != arr[0] {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -39,6 +39,7 @@ type LndhubService struct {
 	RabbitMQClient rabbitmq.Client
 	Logger         *lecho.Logger
 	InvoicePubSub  *Pubsub
+	TaprootAssetPubSub *TapdPubsub
 }
 
 func (svc *LndhubService) ParseInt(value interface{}) (int64, error) {

--- a/lib/service/tahub.go
+++ b/lib/service/tahub.go
@@ -3,13 +3,13 @@ package service
 import (
 	"context"
 	b64 "encoding/base64"
-	"encoding/hex"
+	//"encoding/hex"
 	"fmt"
-	"slices"
-	"strings"
+	//"slices"
+	//"strings"
 
 	"github.com/lightninglabs/taproot-assets/taprpc"
-	"github.com/lightninglabs/taproot-assets/taprpc/universerpc"
+	//"github.com/lightninglabs/taproot-assets/taprpc/universerpc"
 )
 
 type AssetRoot struct {
@@ -18,9 +18,12 @@ type AssetRoot struct {
 	GroupKey   string `json:"group_key"`  
 }
 
+// TODO most of this logic was moved to the universe_to_assets go migration
+//      abstract that to a utility function
 func (svc *LndhubService) GetUniverseAssets(ctx context.Context) (okMsg string, success bool) {
-	req := universerpc.AssetRootRequest{}
-	universeRoots, err := svc.TapdClient.GetUniverseAssets(ctx, &req)
+	// req := universerpc.AssetRootRequest{}
+	// universeRoots, err := svc.TapdClient.GetUniverseAssets(ctx, &req)
+	universeRoots, err := svc.GetAssets(ctx)
 	if err != nil {
 		// TODO OK Relay-Compatible messages need a central location
 		return "error: no assets found, possible disconnect.", false
@@ -28,27 +31,35 @@ func (svc *LndhubService) GetUniverseAssets(ctx context.Context) (okMsg string, 
 	var okSuccessMsg = "uniassets: "
 	// since there can be two root entries per asset (one for issuance and one for transfer: https://lightning.engineering/api-docs/api/taproot-assets/universe/query-asset-roots#universerpcqueryrootresponse)
 	// the observedAssetIds array helps us return something the user expects to see i.e. joins asset/transfer entry if both exist
-	var observedAssetIds = []string{}
+	
+	//var observedAssetIds = []string{}
+
 	// TODO confirm when the key may be the group key hash instead of the assetId
-	for assetId, root := range universeRoots.UniverseRoots {
-		rawAssetId := strings.Split(assetId, "-")[1]
-		seen := slices.Contains(observedAssetIds, rawAssetId)
 
-		if !seen {
-			decoded, err := hex.DecodeString(rawAssetId)
+	// for assetId, root := range universeRoots.UniverseRoots {
+	// 	rawAssetId := strings.Split(assetId, "-")[1]
+	// 	seen := slices.Contains(observedAssetIds, rawAssetId)
 
-			if err != nil {
-				// TODO OK Relay-Compatible messages need a central location
-				return "error: failed to parse assetID.", false				
-			}
+	// 	if !seen {
+	// 		decoded, err := hex.DecodeString(rawAssetId)
 
-			final := b64.StdEncoding.EncodeToString(decoded)
+	// 		if err != nil {
+	// 			// TODO OK Relay-Compatible messages need a central location
+	// 			return "error: failed to parse assetID.", false				
+	// 		}
 
-			appendAsset := fmt.Sprintf("%s %s,", final, root.AssetName)
-			okSuccessMsg = okSuccessMsg + appendAsset
+	// 		final := b64.StdEncoding.EncodeToString(decoded)
 
-			observedAssetIds = append(observedAssetIds, rawAssetId)
-		}
+	// 		appendAsset := fmt.Sprintf("%s %s,", final, root.AssetName)
+	// 		okSuccessMsg = okSuccessMsg + appendAsset
+
+	// 		observedAssetIds = append(observedAssetIds, rawAssetId)
+	// 	}
+	// }
+	for _, asset := range universeRoots {
+		appendAsset := fmt.Sprintf("%s %s,", asset.TaAssetID, asset.AssetName)
+
+		okSuccessMsg = okSuccessMsg + appendAsset
 	}
 
 	return okSuccessMsg, true
@@ -71,4 +82,40 @@ func (svc *LndhubService) GetAddressByAssetId(ctx context.Context, assetId strin
 		return "error: failed to create receive address.", false
 	}
 	return fmt.Sprintf("address: %s", newAddr.Encoded), true
+}
+
+func (svc *LndhubService) FetchOrCreateAssetAddr(ctx context.Context, userId uint64, assetId string, amt uint64) (string, error) {
+	addr, err := svc.FindAddress(ctx, userId, assetId, amt)
+	// check db error
+	if err != nil {
+		return "error: failed to check on existing address.", err
+	}
+	// return if existing address found
+	if addr.ID > 0 {
+		return addr.Address, nil
+	}
+	// decode assetId for tapd request
+	decoded, err := b64.StdEncoding.DecodeString(assetId)
+	if err != nil {
+		// TODO OK Relay-Compatible messages need a central location
+		return "error: failed to parse assetID.", err	
+	}
+	// create new address
+	req := taprpc.NewAddrRequest{
+		AssetId: decoded,
+		Amt: amt,
+	}
+	newAddr, err := svc.TapdClient.NewAddress(ctx, &req)
+	if err != nil {
+		// TODO OK Relay-Compatible messages need a central location
+		return "error: failed to create receive address.", err
+	}
+	// save new address to db
+	_, err = svc.CreateAddress(ctx, newAddr.Encoded, userId, assetId)
+	if err != nil {
+		// TODO OK Relay-Compatible messages need a central location
+		return "error: failed to save receive address.", err
+	}
+	// return success message
+	return fmt.Sprintf("address: %s", newAddr.Encoded), nil
 }

--- a/lib/service/taproot_asset_pubsub.go
+++ b/lib/service/taproot_asset_pubsub.go
@@ -1,0 +1,64 @@
+package service
+
+import (
+	"sync"
+	//"github.com/lightninglabs/taproot-assets/taprpc"
+	//"github.com/getAlby/lndhub.go/db/models"
+)
+
+// This should give enough space to allow for some spike in traffic without flooding memory to much.
+const DefaultTapdChannelBufSize = 20
+
+type TapdPubsub struct {
+	mu   sync.RWMutex
+	subs map[string]map[string]chan bool
+}
+
+func NewTapdPubsub() *TapdPubsub {
+	ps := &TapdPubsub{}
+	ps.subs = make(map[string]map[string]chan bool)
+	return ps
+}
+
+func (ps *TapdPubsub) TapdSubscribe(topic string) (chan bool, string, error) {
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+	if ps.subs[topic] == nil {
+		ps.subs[topic] = make(map[string]chan bool)
+	}
+	//re-use preimage code for a uuid
+	preImageHex, err := makePreimageHex()
+	if err != nil {
+		return nil, "", err
+	}
+	subId := string(preImageHex)
+	ch := make(chan bool, DefaultTapdChannelBufSize)
+	ps.subs[topic][subId] = ch
+	return ch, subId, nil
+}
+
+func (ps *TapdPubsub) TapdUnsubscribe(id string, topic string) {
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+	if ps.subs[topic] == nil {
+		return
+	}
+	if ps.subs[topic][id] == nil {
+		return
+	}
+	close(ps.subs[topic][id])
+	delete(ps.subs[topic], id)
+}
+
+func (ps *TapdPubsub) TapdPublish(topic string, msg bool) {
+	ps.mu.RLock()
+	defer ps.mu.RUnlock()
+
+	if ps.subs[topic] == nil {
+		return
+	}
+
+	for _, ch := range ps.subs[topic] {
+		ch <- msg
+	}
+}

--- a/lib/service/webhook.go
+++ b/lib/service/webhook.go
@@ -93,6 +93,19 @@ func (svc *LndhubService) SubscribeIncomingOutgoingInvoices() (incoming, outgoin
 	return incomingInvoices, outgoingInvoices, nil
 }
 
+func (svc LndhubService) SubscribeTaprootAssetTransfers() (rcvResponse, sendResponse chan bool, err error) {
+	rcvResponse, _, err = svc.TaprootAssetPubSub.TapdSubscribe(common.TapdReceiveEvent)
+	if err != nil {
+		return nil, nil, err
+	}
+	sendResponse, _, err = svc.TaprootAssetPubSub.TapdSubscribe(common.TapdSendEvent)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return rcvResponse, sendResponse, nil
+}
+
 func (svc *LndhubService) EncodeInvoiceWithUserLogin(ctx context.Context, w io.Writer, invoice models.Invoice) error {
 	user, err := svc.FindUser(ctx, invoice.UserID)
 	if err != nil {

--- a/tapd/tapd.go
+++ b/tapd/tapd.go
@@ -126,3 +126,7 @@ func (wrapper *TAPDWrapper) GetUniverseAssets(ctx context.Context, req *universe
 func (wrapper *TAPDWrapper) NewAddress(ctx context.Context, req *taprpc.NewAddrRequest, options ...grpc.CallOption) (*taprpc.Addr, error) {
 	return wrapper.client.NewAddr(ctx, req, options...)
 }
+
+func (wrapper *TAPDWrapper) SubscribeReceiveAssetEvent(ctx context.Context, req *taprpc.SubscribeReceiveAssetEventNtfnsRequest, options ...grpc.CallOption) (SubscribeReceiveAssetEventWrapper, error) {
+	return wrapper.client.SubscribeReceiveAssetEventNtfns(ctx, req, options...)
+}

--- a/tapd/tapd_client.go
+++ b/tapd/tapd_client.go
@@ -20,6 +20,11 @@ type TapdClientWrapper interface {
 	//ListBalancesByAssetID(ctx context.Context, req *taprpc.ListBalancesRequest_AssetId, options ...grpc.CallOption) (*taprpc.ListBalancesResponse, error)
 	NewAddress(ctx context.Context, req *taprpc.NewAddrRequest, options ...grpc.CallOption) (*taprpc.Addr, error)
 	GetUniverseAssets(ctx context.Context, req *universerpc.AssetRootRequest, options ...grpc.CallOption) (*universerpc.AssetRootResponse, error)
+	SubscribeReceiveAssetEvent(ctx context.Context, req *taprpc.SubscribeReceiveAssetEventNtfnsRequest, options ...grpc.CallOption) (SubscribeReceiveAssetEventWrapper, error)
+}
+
+type SubscribeReceiveAssetEventWrapper interface {
+	Recv() (*taprpc.ReceiveAssetEvent, error)
 }
 
 func InitTAPDClient(c *TapdConfig, logger *lecho.Logger, ctx context.Context) (TapdClientWrapper, error) {


### PR DESCRIPTION
Addresses are intended to be an mvp-only link between users balances and non-segregated pools of Lndhub's taproot asset portfolio. Ultimately, lit accounts look like the best candidate that exists today but ideally there is a way to cryptographically link "leaves" to users or have users provide their own receive addresses opting more towards non-custodial models.